### PR TITLE
Make Sling-Initial-Content more specific

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,2 +1,2 @@
-Sling-Initial-Content: SLING-INF;overwrite=true
+Sling-Initial-Content: SLING-INF/apps/repl/components/repl;overwrite=true;path=/apps/repl/components/repl,SLING-INF/content/htl/repl.json;overwrite=true;path=/content/htl/repl,SLING-INF/etc/clientlibs/repl;overwrite=true;path=/etc/clientlibs/repl
 Require-Capability:    io.sightly; filter:="(&(version>=1.0)(!(version>=2.0)))"

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,2 +1,4 @@
-Sling-Initial-Content: SLING-INF/apps/repl/components/repl;overwrite=true;path=/apps/repl/components/repl,SLING-INF/content/htl/repl.json;overwrite=true;path=/content/htl/repl,SLING-INF/etc/clientlibs/repl;overwrite=true;path=/etc/clientlibs/repl
+Sling-Initial-Content: SLING-INF/apps/repl/components/repl;overwrite:=true;path:=/apps/repl/components/repl,\
+    SLING-INF/content/htl/repl.json;overwrite:=true;path:=/content/htl/repl,\
+    SLING-INF/etc/clientlibs/repl;overwrite:=true;path:=/etc/clientlibs/repl
 Require-Capability:    io.sightly; filter:="(&(version>=1.0)(!(version>=2.0)))"


### PR DESCRIPTION
This prevents overwriting other nodes and ACLs at /apps, /content or /etc