### PR TITLE
SLING-10987 - Don't overwrite/remove nodes outside the nodes really owned by HTL REPL

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,4 +1,4 @@
 Sling-Initial-Content: SLING-INF/apps/repl/components/repl;overwrite:=true;path:=/apps/repl/components/repl,\
-    SLING-INF/content/htl/repl.json;overwrite:=true;path:=/content/htl,\
+    SLING-INF/content/htl;overwrite:=true;path:=/content/htl,\
     SLING-INF/etc/clientlibs/repl;overwrite:=true;path:=/etc/clientlibs/repl
 Require-Capability:    io.sightly; filter:="(&(version>=1.0)(!(version>=2.0)))"

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,4 +1,4 @@
 Sling-Initial-Content: SLING-INF/apps/repl/components/repl;overwrite:=true;path:=/apps/repl/components/repl,\
-    SLING-INF/content/htl/repl.json;overwrite:=true;path:=/content/htl/repl,\
+    SLING-INF/content/htl/repl.json;overwrite:=true;path:=/content/htl,\
     SLING-INF/etc/clientlibs/repl;overwrite:=true;path:=/etc/clientlibs/repl
 Require-Capability:    io.sightly; filter:="(&(version>=1.0)(!(version>=2.0)))"


### PR DESCRIPTION
Fix path for /content/htl/repl. Without this change, content would be installed under
/content/htl/repl/repl, breaking the bundle's functionality.